### PR TITLE
check also for empty string before creating a wallet

### DIFF
--- a/Terra Planet/API/KeyChainManager.swift
+++ b/Terra Planet/API/KeyChainManager.swift
@@ -52,7 +52,7 @@ final class KeyChainManager {
                 if let retrievedData = extractedData as? Data,
                     let credentials: [String : String] = NSKeyedUnarchiver.unarchiveObject(with: retrievedData) as? [String : String] {
                     print(credentials)
-                    if let address = credentials["address"], let mnemonic = credentials["mnemonic"] {
+                    if let address = credentials["address"], let mnemonic = credentials["mnemonic"], !address.isEmpty, !mnemonic.isEmpty {
                         API.shared.wallet = Wallet(address: address, mnemonic: mnemonic, coins: [:])
                         callback(true)
                     }


### PR DESCRIPTION
…, and couldnt continue using the app.

Doesn't make  sense to create a Wallet for a empty mnemonic. i had one somehow due to a possible bug i have to figure out