### PR TITLE
Enhancement: modified TextField styling in order to support dark mode on ImportWalletVC

### DIFF
--- a/Terra Planet/Views/Onboarding/Onboarding.storyboard
+++ b/Terra Planet/Views/Onboarding/Onboarding.storyboard
@@ -119,11 +119,11 @@
                             </label>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="12f-i8-i1E">
                                 <rect key="frame" x="20" y="166" width="374" height="128"/>
-                                <color key="backgroundColor" name="color_blue"/>
+                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.20000000000000001" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="128" id="IoK-nX-k4N"/>
                                 </constraints>
-                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                 <userDefinedRuntimeAttributes>
@@ -332,6 +332,9 @@
         <namedColor name="color_blue">
             <color red="0.10980392156862745" green="0.23137254901960785" blue="0.62352941176470589" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
         </namedColor>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Terra Planet/Views/Onboarding/Onboarding.storyboard
+++ b/Terra Planet/Views/Onboarding/Onboarding.storyboard
@@ -119,11 +119,11 @@
                             </label>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="12f-i8-i1E">
                                 <rect key="frame" x="20" y="166" width="374" height="128"/>
-                                <color key="backgroundColor" systemColor="systemGray6Color"/>
+                                <color key="backgroundColor" name="color_blue"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="128" id="IoK-nX-k4N"/>
                                 </constraints>
-                                <color key="textColor" systemColor="labelColor"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                 <userDefinedRuntimeAttributes>
@@ -332,14 +332,8 @@
         <namedColor name="color_blue">
             <color red="0.10980392156862745" green="0.23137254901960785" blue="0.62352941176470589" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
         </namedColor>
-        <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemGray6Color">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
### Summary

Seed phrase `TextField` is not visible when iOS appearance is on dark mode:

![IMG_0420](https://user-images.githubusercontent.com/14587789/163891970-df75f93d-7351-4a19-b8c7-2d3c5be3670d.PNG)

while it's visible on light mode:

![IMG_0421](https://user-images.githubusercontent.com/14587789/163892008-3a2834c6-3f61-41bf-bfe1-89e5cad81755.PNG)

I modified the `backgroundColor` and `textColor` to match the same design as other subviews on `NewWalletInfoVC` that can be seen well with dark mode enabled:

![IMG_0422](https://user-images.githubusercontent.com/14587789/163892230-ef39c802-1e36-4c5a-8d87-e9aad55c5951.PNG)

The result in both appearances:

![IMG_0423](https://user-images.githubusercontent.com/14587789/163892252-698654ef-e7a8-43eb-aa91-7cb0570fbbf9.PNG)

![IMG_0424](https://user-images.githubusercontent.com/14587789/163892264-05a4b481-28eb-44d6-9537-5dcd32c03ded.PNG)

